### PR TITLE
Upgrade cuda to upgrade ubuntu to upgrade ffmpeg

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -1,6 +1,6 @@
 build:
   gpu: true
-  cuda: "11.3"
+  cuda: "11.7"
   python_version: "3.8"
   system_packages:
     - "ffmpeg"


### PR DESCRIPTION
Using this patch relies on this PR being included in your `cog` binary

https://github.com/replicate/cog/pull/779

The version of CUDA changes the docker image that is used as a base.